### PR TITLE
fix a bug that prevented deleteMany from deleting documents

### DIFF
--- a/lib/query.ts
+++ b/lib/query.ts
@@ -770,14 +770,15 @@ class Query {
         if (typeof options === 'function') {
           callback = options;
           options = {};
-
-          const data = await collection.deleteMany(document, options);
-          const formattedReturnObj = { deletedCount: data };
-          console.log(formattedReturnObj);
-          if (callback) return callback(data);
-
-          return formattedReturnObj;
         }
+        
+        const data = await collection.deleteMany(document, options);
+        const formattedReturnObj = { deletedCount: data };
+        console.log(formattedReturnObj);
+        if (callback) return callback(data);
+
+        return formattedReturnObj;
+        
       }
     } catch (error) {
       throw new Error(`Error in deleteMany function. ${error}`);


### PR DESCRIPTION
# Checklist

- [x] Bugfix
- [ ] New feature
- [ ] Refactor

# Related Issue

- This PR fixes #47 bug that prevented `Model.deleteMany({})` from deleting documents when a condition object is provided.

# Solution

- There was a misplaced closing curly brace of an `if` statement that needed to be placed correctly.

# Additional Info

- With this fix, it is now possible to delete documents by providing a condition object to `Model.deleteMany({})`