### PR TITLE
Proposal: Add select to schema options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ First, be sure that you have [Deno](https://deno.land) runtime installed and con
 
 ### Quick Start
 
-In your application, import the dangoDB module from the [deno.land module](https://deno.land/x/dangodb.mod.ts).
+In your application, import the dangoDB module from the deno.land [module](https://doc.deno.land/https://deno.land/x/dangodb@v1.0.1/mod.ts/~/dango).
 
 ```javascript
-import { dango } from 'https://deno.land/x/dangodb.mod.ts'
+import { dango } from "https://deno.land/x/dangodb@v1.0.2/mod.ts";
 ```
 
 ### Connect to your Database
@@ -111,7 +111,7 @@ console.log(dinosaurs);
 Now you've successfully inserted a document into the Dinosaur collection at your MongoDB database. 
 
 Congratulations! That's the end of the quick start. You've successfully imported dangoDB, opened up a connection, created a schema, inserted a document for Stegosaurus, and
-queried all the dinosaurs in your Dinosaur model in your MongoDB database using dangoDB. Explore the rest of the readme.MD for more detailed instructions on how to use dangoDB.
+queried all the dinosaurs in your Dinosaur model using dangoDB. Explore the rest of the readme.MD for more detailed instructions on how to use dangoDB.
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <br>
 <div align="center"><a href="https://dangodb.land">Visit our Website</a></div>
 <br>
-<div align="center"><a href="https://dangodb-website.web.app/">Read our Medium Launch Article</a></div>
+<div align="center"><a href="https://medium.com/@stephen-jue/dangodb-a-mongodb-odm-for-deno-9ac46943fe54">Read our Medium Launch Article</a></div>
 <br>
 
 ## Table of Contents
@@ -24,7 +24,7 @@
 
 <strong>dangoDB</strong> is a light-weight MongoDB Object Document Mapper (ODM) library built for the Deno runtime. It provides the core functionality and familiar look and feel of established Node-based libraries. With dangoDB, developers can construct schemas and models, and they can enforce strict type-casting and schema validation to structure their databases. The query functions available from the deno_mongo driver can all be accessed with ease. 
 
-In addition, we built a user-friendly web-based [GUI](https://dangodb.land/schema) that auto-generates schema for users to copy and paste directly into their code. 
+In addition, we built a user-friendly web-based [GUI](https://dangodb.land/#/schema) that auto-generates schema for users to copy and paste directly into their code. 
 
 
 ## <a name="get-started"></a>Getting Started
@@ -33,7 +33,7 @@ First, be sure that you have [Deno](https://deno.land) runtime installed and con
 
 ### Quick Start
 
-In your application, import the dangoDB module from the deno.land [module](https://doc.deno.land/https://deno.land/x/dangodb@v1.0.1/mod.ts/~/dango).
+In your application, import the dangoDB module from the deno.land [module](https://deno.land/x/dangodb).
 
 ```javascript
 import { dango } from "https://deno.land/x/dangodb@v1.0.2/mod.ts";

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -101,7 +101,6 @@ class Query {
         }
       } else {
         const collection = this.connection.db.collection(this.collectionName);
-        console.log(queryObject)
         const data = await collection.findOne(queryObject, options);
 
         if (callback) return callback(data);

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1129,24 +1129,25 @@ class Query {
     return true;
   }
 
-    /**
-   * Method loops through all properties in the given schema and attempts to remove each property with select set as false from the current query.
-   *
-   * @param document which is the matched document from the database
-   * @param schemaMap which contains the schemaMap for the current level in the user's document
-   * @returns the document with filtered fields.
-   */
-     filterSelectedFields(
-      document: Record<string, unknown>,
-      schemaMap: Record<string, optionsObject>,
-    ) {
-      Object.entries(schemaMap).forEach(([propertyName, propertyOptions]) => {
-        if (!propertyOptions.select) {
-            delete document[propertyName];
-        }
-      })
-      return document;
-    }
+   /**
+  * Method loops through all properties in the given schema and attempts to remove each property with select set as false from the current query.
+  *
+  * @param document which is the matched document from the database
+  * @param schemaMap which contains the schemaMap for the current level in the user's document
+  * @returns the document with filtered fields.
+  */
+  filterSelectedFields(
+   document: Record<string, unknown>,
+   schemaMap: Record<string, optionsObject>,
+   ) {
+    Object.entries(schemaMap).forEach(([propertyName, propertyOptions]) => {
+     if (!propertyOptions.select) {
+         delete document[propertyName];
+     }
+   })
+   return document;
+  }
+   
 
   /**
    * Method populates the property updatedQueryObject object to be used in the actual query.

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -57,6 +57,7 @@ export interface optionsObject {
   unique?: boolean;
   default?: any;
   validator?: Function | null;
+  select?: boolean;
 }
 
 /**
@@ -72,6 +73,7 @@ export class SchemaOptions {
   unique?: boolean;
   default?: any;
   validator?: Function | null;
+  select?: boolean;
 
   constructor(options: optionsObject) {
     if (!Object.prototype.hasOwnProperty.call(options, 'type')) {
@@ -82,6 +84,7 @@ export class SchemaOptions {
     this.unique = false;
     this.default = null;
     this.validator = null;
+    this.select = true;
     for (const key in options) {
       if (key === 'type') {
         if (Object.prototype.hasOwnProperty.call(dango.types, options[key])) {

--- a/tests/test_query.ts
+++ b/tests/test_query.ts
@@ -1,4 +1,5 @@
 import {
+  assert,
   assertInstanceOf,
   assertStrictEquals,
   assertThrows,
@@ -15,7 +16,7 @@ import { model } from '../lib/model.ts';
 
 import { Bson } from '../deps.ts';
 
-import { Schema, SchemaOptions } from '../lib/schema.ts';
+import { Schema, SchemaOptions, optionsObject } from '../lib/schema.ts';
 
 import { dango } from '../lib/dango.ts';
 
@@ -34,6 +35,10 @@ describe('test Query methods', () => {
       type: 'number',
       required: false,
       default: null,
+    },
+    password: {
+      type: 'string',
+      select: false,
     },
   };
 
@@ -187,6 +192,21 @@ describe('test Query methods', () => {
     const updatedQueryObjectKeys = Object.keys(query.updatedQueryObject);
     it('will reset updatedQuery object', () => {
       assertStrictEquals(updatedQueryObjectKeys.length, 0);
+    });
+  });
+
+  describe('filterSelectedFields result ', () => {
+    let document: Record<string, unknown>;
+    let schemaMap: Record<string, optionsObject>;
+    
+    beforeEach(() => {
+      document = { name: 'Mr. A', age: 25, password: '123456' };
+      schemaMap = testSchema.schemaMap;
+    });
+
+    it('will delete property from document when the property option select is false', () => {
+      query.filterSelectedFields(document, schemaMap);
+      assert(!Object.keys(document).includes('password'));
     });
   });
 


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [X] New feature
- [ ] Refactor

# Related Issue
Hey y'all! Been trying this lib with the stable release of [fresh](https://deno.com/blog/fresh-is-stable) and I'm loving to work with dangoDB on it :) 

This PR proposes including the select option to the SchemaOptions. The select option provides a way to obfuscate any document property when you run queries that returns a document.

I'm not sure if you guys are taking new features proposals but since I was implementing this one for myself I decided to share this solution. 

# Solution

This code implements the `select` option to the SchemaOptions. The `select` is intialized as `true`. If a property has `select` as `false`, any query should remove the field from the result document.

This PR ships the method `Query.filterSelectedFields` to filter any given document from a SchemaMap and implements it in `Query.find` and `Query.findById`.

If approved, the next steps would be to use `Query.filterSelectedFields` on every query that returns a document
