### PR TITLE
Support function type as the default schema option

### DIFF
--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1120,7 +1120,11 @@ class Query {
     propertyOptions: optionsObject
   ) {
     if (!Object.prototype.hasOwnProperty.call(queryObject, propertyName)) {
-      queryObject[propertyName] = propertyOptions.default;
+      if (typeof propertyOptions.default === 'function') {
+        queryObject[propertyName] = propertyOptions.default();
+      } else {
+        queryObject[propertyName] = propertyOptions.default;
+      }
     }
     return true;
   }

--- a/tests/test_query.ts
+++ b/tests/test_query.ts
@@ -111,7 +111,7 @@ describe('test Query methods', () => {
       propertyName = 'createdAt'
       propertyOptions = testSchema.schemaMap[propertyName];
       query.setDefault(queryObject, propertyName, propertyOptions);
-      assertInstanceOf(queryObject['createdAt'], Date);
+      assertInstanceOf(queryObject[propertyName], Date);
     })
 
     it('will not assign a default value to a property in queryObject if it already has an assigned value', () => {

--- a/tests/test_query.ts
+++ b/tests/test_query.ts
@@ -35,6 +35,11 @@ describe('test Query methods', () => {
       required: false,
       default: null,
     },
+    createdAt: {
+      type: 'date',
+      required: false,
+      default: () => new Date()
+    }
   };
 
   const collectionName = 'testCollection';
@@ -100,6 +105,14 @@ describe('test Query methods', () => {
       query.setDefault(queryObject, propertyName, propertyOptions);
       assertStrictEquals(queryObject[propertyName], null);
     });
+
+    it('will set property value in queryObject by calling default if it is a function', () => {
+      queryObject = { name: 'Mr. D' };
+      propertyName = 'createdAt'
+      propertyOptions = testSchema.schemaMap[propertyName];
+      query.setDefault(queryObject, propertyName, propertyOptions);
+      assertInstanceOf(queryObject['createdAt'], Date);
+    })
 
     it('will not assign a default value to a property in queryObject if it already has an assigned value', () => {
       queryObject = { name: 'Mr. D', occupation: 'baker' };


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [x] New feature
- [ ] Refactor

# Related Issue

A function cannot be assigned to the `default` schema option, which makes it impossible to set dynamic values such as timestamps to a newly created document.

# Solution

This PR provides the ability to assign a function to the `default` schema option. The function will be called and the returned value will be assigned to the document.

```typescript
const userSchema = dango.schema({
  name: { type: 'string', required: true },
  createdAt: {
    type: 'date',
    default: () => Date.now(),
  },
});
const User = dango.model('user', userSchema);

const _id = await User.insertOne({ name: 'Jane' });
console.log(await User.findById(_id));
```
```
{
  name: "Jane",
  createdAt: 2022-08-22T10:52:30.699Z
}
```