### PR TITLE
Change to checkDataFields commenting for improved clarity

### DIFF
--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1092,7 +1092,7 @@ class Query {
     index?: number
   ) {
     for (let property in queryObject) {
-      // if nested document is being checked, parse it
+      // if nested property within a nested document is being checked, parse it
       if(property.includes('.')) {
         property = property.split('.')[index as number];
         console.log('inside checkDataFields for nestedDoc, currentProperty: ', property);


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [ ] New feature
- [x] Refactor

# Related Issue
Original comment related to line 1095 of query.ts of checkDataFields did not specifically mention what was being parsed. 

# Solution
Updated the comment to clarify that if nested property was being checked, then parsing would be required. Example, 'address.zipcode' includes a period with the nested property to the right of the period, therefore it would be parsed per condition of line 1096.

# Additional Info