### PR TITLE
Removal of Dotenv package and replaced with dotenv from standard library

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -54,5 +54,4 @@ export {
   unreachable,
 } from 'https://deno.land/std@0.138.0/testing/asserts.ts';
 
-import * as dotenv from "https://deno.land/x/dotenv@v3.2.0/mod.ts";
-export { dotenv }
+export { load } from "https://deno.land/std/dotenv/mod.ts";

--- a/tests/test_connections.ts
+++ b/tests/test_connections.ts
@@ -1,6 +1,7 @@
 // Required Flags for Test:
 //  - --allow-read
 //  - --allow-net
+//  - --allow-env
 
 import {
   assertInstanceOf,
@@ -13,13 +14,14 @@ import {
   it,
 } from '../deps.ts';
 
-import { dotenv } from '../deps.ts';
+import { load } from '../deps.ts';
 
 import { MongoClient, Database } from '../deps.ts';
 
 import { Connection } from '../lib/connections.ts';
 
-const ENV = dotenv.config({ path: '../.env' });
+const env = await load();
+const CONNECTION_STRING = env["URI_STRING"];
 
 describe('Connection constructor', () => {
   let newObject: unknown;
@@ -33,7 +35,7 @@ describe('Connection constructor', () => {
   });
   describe('creating an instance of the class with a valid URI string', () => {
     beforeEach(() => {
-      newObject = new Connection(ENV.URI_STRING);
+      newObject = new Connection(CONNECTION_STRING);
     });
     it('will create an instance of the class', () => {
       assertInstanceOf(newObject, Connection);
@@ -46,7 +48,7 @@ describe('Connection constructor', () => {
     it('will have a connectionString property assigned the value of the URI connection string', () => {
       if (newObject instanceof Connection) {
         //@ts-ignore Ignore TS warning to run test
-        assertStrictEquals(newObject.connectionString, ENV.URI_STRING);
+        assertStrictEquals(newObject.connectionString, CONNECTION_STRING);
       }
     });
     it('will have a db property assigned the value of false', () => {
@@ -77,7 +79,7 @@ describe('Connection methods', () => {
   describe('using the connect method', () => {
     describe('creating a Connection object with a valid URI', () => {
       beforeEach(() => {
-        newObject = new Connection(ENV.URI_STRING);
+        newObject = new Connection(CONNECTION_STRING);
       });
       afterEach(async () => {
         if (newObject instanceof Connection) {
@@ -138,7 +140,7 @@ describe('Connection methods', () => {
   describe('using the disconnect method', () => {
     describe('invoking disconnect after a connection is established', () => {
       beforeEach(() => {
-        newObject = new Connection(ENV.URI_STRING);
+        newObject = new Connection(CONNECTION_STRING);
       });
       it('should reset the value of the connected property', async () => {
         if (newObject instanceof Connection) {

--- a/tests/test_integrated_core_query_methods.ts
+++ b/tests/test_integrated_core_query_methods.ts
@@ -26,7 +26,7 @@ import { Schema, SchemaOptions } from '../lib/schema.ts';
 import { dango } from '../lib/dango.ts';
 import { afterAll, beforeAll } from '../deps.ts';
 import { assertEquals } from '../deps.ts';
-import { load } from "https://deno.land/std/dotenv/mod.ts";
+import { load } from '../deps.ts';
 
 interface Person {
   firstName: string,
@@ -46,10 +46,10 @@ interface Address {
 }
 
 const env = await load();
-const connection_string = env["URI_STRING"];
+const CONNECTION_STRING = env["URI_STRING"];
 
 describe('Core query methods', async () => {
-  if(!connection_string) {
+  if(!CONNECTION_STRING) {
     console.log('No Connection String, ending test_unit_core_query_method tests');
     return;
   }
@@ -61,7 +61,7 @@ describe('Core query methods', async () => {
 
   beforeAll( async () => {
 
-    await dango.connect(connection_string);
+    await dango.connect(CONNECTION_STRING);
 
     const addressSchemaTemplate = {
       type: 'string',

--- a/tests/test_integrated_noncore_query_methods.ts
+++ b/tests/test_integrated_noncore_query_methods.ts
@@ -1,6 +1,7 @@
 // Required Flags for Test:
 //  - --allow-read
 //  - --allow-net
+//  - --allow-env
 
 import {
   assertEquals,
@@ -8,20 +9,19 @@ import {
   beforeAll,
   describe,
   it,
-  dotenv,
   // @ts-ignore
 } from '../deps.ts';
 
 import { dango } from '../lib/dango.ts';
-
+import { load } from '../deps.ts';
 import { mockAddress } from './mock_address.js';
 
-const ENV = dotenv.config({ path: '../.env'});
-const connection_string = ENV.URI_STRING;
+const env = await load();
+const CONNECTION_STRING = env["URI_STRING"];
 
 describe('non-core query methods', async () => {
 
-  if(!connection_string) {
+  if(!CONNECTION_STRING) {
     console.log('No Connection String, ending test_unit_other_query tests');
     return;
   }
@@ -32,7 +32,7 @@ describe('non-core query methods', async () => {
 
   beforeAll( async () => {
 
-    await dango.connect(connection_string);
+    await dango.connect(CONNECTION_STRING);
 
     const addressSchemaTemplate = {
       type: 'string',

--- a/tests/test_query.ts
+++ b/tests/test_query.ts
@@ -7,12 +7,6 @@ import {
   it,
 } from '../deps.ts';
 
-// import {
-//   Query
-// } from '../lib/query.ts';
-
-import { model } from '../lib/model.ts';
-
 import { Bson } from '../deps.ts';
 
 import { Schema, SchemaOptions } from '../lib/schema.ts';
@@ -39,18 +33,15 @@ describe('test Query methods', () => {
 
   const collectionName = 'testCollection';
   const testSchema = dango.schema(UserSchema);
-  // console.log('testSchema: ', testSchema);
   let queryObject: Record<string, unknown>;
 
   const query = dango.model(collectionName, testSchema);
 
   describe('checkDataFields', () => {
-    // let queryObject: Record<string, unknown>;
     let schemaMap: Record<string, unknown>;
 
     schemaMap = testSchema.schemaMap;
     queryObject = { name: 'Mr. A', age: 25 };
-    // console.log('queryObject: ', queryObject);
     it('it will throw an error if extra properties are present in the queryObject', () => {
       queryObject = { name: 'Mr. A', school: 'Furinkan HS' };
       assertThrows(() => query.checkDataFields(queryObject, schemaMap));
@@ -92,7 +83,6 @@ describe('test Query methods', () => {
     beforeEach(() => {
       propertyName = 'occupation';
       propertyOptions = testSchema.schemaMap[propertyName];
-      // queryObject = { name: 'Mr. D' };
     });
 
     it('will set property value in queryObject to default if value not assigned', () => {
@@ -156,16 +146,6 @@ describe('test Query methods', () => {
       });
     });
   });
-
-  // need to figure out how to mock or craete a fake evalauted result from invoking findOne query
-  // describe('checkUnique', () => {
-  //   let propertyName: string;
-  //   let propertyOptions: SchemaOptions;
-  //   let updatedQueryObject: Record<string, unknown> = {};
-  //   let embeddedUniqueProperty: string[];
-  // })
-
-  // checkUniqueForReplace
 
   describe('checkConstraints', () => {
     let propertyName: string;


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [x] Update

# Related Issue
3rd party Dotnev package no longer working - unable to properly use to access variables from .env file, affecting test files.

# Solution
Removed references to 3rd party Dotenv package and replaced it with load function from dotenv of standard library at deps.ts, the following files: test_connections.ts, test_integrated_core_query_methods.ts, test_integrated_noncore_query_methods.ts, and deps.ts. Removed extra comments from test_query.ts.