### PR TITLE
type annotation for updatedQueryObject of query.ts

### DIFF
--- a/lib/query.ts
+++ b/lib/query.ts
@@ -28,11 +28,13 @@ interface GroupInterface {
   };
 }
 
+type updatedQueryObjectProp = { [key: string]: unknown };
+
 class Query {
   public collectionName: string;
   public connection: Connection | boolean;
   public schema: Schema;
-  public updatedQueryObject: { [key: string]: unknown };
+  public updatedQueryObject: updatedQueryObjectProp;
 
   constructor(collectionName: string, schema: Schema) {
     this.collectionName = collectionName;
@@ -469,7 +471,7 @@ class Query {
         if (typeof options === 'function') callback = options;
         options = {};
 
-        const validatedDocuments = [];
+        const validatedDocuments: updatedQueryObjectProp[] = [];
         for (const doc of document) {
           await this.validateInsertAgainstSchema(
             doc,


### PR DESCRIPTION
Created type annotation for updatedQueryObject, updatedQueryObjectProp. Assigned type to validatedDocuments array in insertMany method of query.ts.

# Checklist

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [x] Update 

# Related Issue
validatedDocuments array of insertMany method of query.ts was missing type annotation.

# Solution
Create a type annotation for updatedQueryObject to be used with updatedQueryObject and validatedDocuments in insertMany.
