### PR TITLE
Selecting database name when connecting to MongoDB database

### DIFF
--- a/lib/connections.ts
+++ b/lib/connections.ts
@@ -10,12 +10,14 @@ class Connection {
   private client!: MongoClient;
   public connected: boolean;
   public db: Database | boolean;
+  public databaseName: string;
 
-  constructor(private connectionString: string) {
+  constructor(private connectionString: string, databaseName: string) {
     if (!connectionString)
       throw new Error('Connect method requires at least one argument');
     this.connected = false;
     this.connectionString = connectionString;
+    this.databaseName = databaseName;
     this.db = false;
   }
 
@@ -26,7 +28,8 @@ class Connection {
   public async connect() {
     try {
       this.client = new MongoClient();
-      const db = await this.client.connect(this.connectionString);
+      await this.client.connect(this.connectionString);
+      const db = this.client.database(this.databaseName);
       this.connected = true;
       console.log('Connected to Database.');
       this.db = db;

--- a/lib/dango.ts
+++ b/lib/dango.ts
@@ -50,8 +50,8 @@ class Dango {
    *
    * @returns The connection object.
    */
-  async connect(connectionString: string) {
-    this.currentConnection = new Connection(connectionString);
+  async connect(connectionString: string, databaseName: string) {
+    this.currentConnection = new Connection(connectionString, databaseName);
     await this.currentConnection.connect();
     return this.currentConnection;
   }

--- a/lib/model.ts
+++ b/lib/model.ts
@@ -28,7 +28,6 @@ class Model extends Query {
 
   constructor(collectionName: string, schema: Schema) {
     super(collectionName, schema);
-    //TODO: Can we delete these
     this.collectionName = collectionName;
     this.schema = schema;
   }

--- a/tests/test_connections.ts
+++ b/tests/test_connections.ts
@@ -22,6 +22,7 @@ import { Connection } from '../lib/connections.ts';
 
 const env = await load();
 const CONNECTION_STRING = env["URI_STRING"];
+const databaseName = 'testDB';
 
 describe('Connection constructor', () => {
   let newObject: unknown;
@@ -35,7 +36,7 @@ describe('Connection constructor', () => {
   });
   describe('creating an instance of the class with a valid URI string', () => {
     beforeEach(() => {
-      newObject = new Connection(CONNECTION_STRING);
+      newObject = new Connection(CONNECTION_STRING, databaseName);
     });
     it('will create an instance of the class', () => {
       assertInstanceOf(newObject, Connection);
@@ -79,7 +80,7 @@ describe('Connection methods', () => {
   describe('using the connect method', () => {
     describe('creating a Connection object with a valid URI', () => {
       beforeEach(() => {
-        newObject = new Connection(CONNECTION_STRING);
+        newObject = new Connection(CONNECTION_STRING, databaseName);
       });
       afterEach(async () => {
         if (newObject instanceof Connection) {
@@ -108,7 +109,7 @@ describe('Connection methods', () => {
     });
     describe('creating a Connection object with an invalid URI', () => {
       beforeEach(() => {
-        newObject = new Connection('BAD_URI_STRING');
+        newObject = new Connection('BAD_URI_STRING', databaseName);
       });
       it('will throw an error', async () => {
         await assertRejects(async () => {
@@ -140,7 +141,7 @@ describe('Connection methods', () => {
   describe('using the disconnect method', () => {
     describe('invoking disconnect after a connection is established', () => {
       beforeEach(() => {
-        newObject = new Connection(CONNECTION_STRING);
+        newObject = new Connection(CONNECTION_STRING, databaseName);
       });
       it('should reset the value of the connected property', async () => {
         if (newObject instanceof Connection) {

--- a/tests/test_integrated_core_query_methods.ts
+++ b/tests/test_integrated_core_query_methods.ts
@@ -61,9 +61,11 @@ describe('core query methods - insertOne and insertMany', async () => {
 
   let queryObject: Record<string, unknown>;
 
+  const databaseName = 'testDB';
+
   beforeAll( async () => {
 
-    await dango.connect(CONNECTION_STRING);
+    await dango.connect(CONNECTION_STRING, databaseName);
 
     const addressSchemaTemplate = {
       type: 'string',
@@ -147,12 +149,13 @@ describe('Core query methods', async () => {
 
   let directoryQuery: any;
   let firstNameCount = 0;
+  const databaseName = 'testDB';
 
   let queryObject: Record<string, unknown>;
 
   beforeAll( async () => {
 
-    await dango.connect(CONNECTION_STRING);
+    await dango.connect(CONNECTION_STRING, databaseName);
 
     const addressSchemaTemplate = {
       type: 'string',

--- a/tests/test_integrated_noncore_query_methods.ts
+++ b/tests/test_integrated_noncore_query_methods.ts
@@ -28,11 +28,13 @@ describe('non-core query methods', async () => {
 
   let directoryQuery: any;
 
+  const databaseName = 'testDB';
+
   let queryObject: Record<string, unknown>;
 
   beforeAll( async () => {
 
-    await dango.connect(CONNECTION_STRING);
+    await dango.connect(CONNECTION_STRING, databaseName);
 
     const addressSchemaTemplate = {
       type: 'string',


### PR DESCRIPTION
# Checklist

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor
- [x] Update

# Related Issue
When connecting to MongoDB Atlas using an srv url string, there wasn't an option to input your database name. It defaulted to 'db'. 

# Solution
In the Connection class, connect method, called native driver database method passing in user input database name to select user specified database. databaseName parameter set up for Connection constructor, and dango.connect.

When starting a new connection to MongoDB, user now required to pass in databaseName as a parameter.

#Additional Info
Also updated test files test_connections, test_integrated_core_query_methods.ts, test_integrated_noncore_query_methods.ts to reflect requirement of databaseName when invoking connect method.
